### PR TITLE
Add GH Action to publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: Deploy to GitHub Pages 
+
+on: 
+    push:
+        branches:
+            - master
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set Up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install Dependencies
+        run: |
+          pip install mkdocs
+          pip install mkdocs-material
+
+      - name: Build and Deploy
+        run: |
+          mkdocs build 
+          mkdocs gh-deploy --clean

--- a/README.md
+++ b/README.md
@@ -4,36 +4,47 @@
 
 This is the repository backing the site hosted at [handbook.vantage.sh](http://handbook.vantage.sh/).
 
-The Cloud Cost Handbook is a free, open-source, community-supported set of guides meant to help explain often-times complex pricing of public cloud infrastructure and service providers in "plain english". This guide is is open for anyone to contribute their knowledge to the community. [Vantage](http://vantage.sh/) employees will maintain hosting the guide for everyone and ensure that content is relevant and adheres to styleguides.
+The Cloud Cost Handbook is a free open-source community-supported set of guides meant to help explain the complex pricing of public cloud infrastructure and service providers in "plain English." This guide is open for anyone to contribute their knowledge to the community. [Vantage](http://vantage.sh/) employees will maintain hosting the guide for everyone and ensure that content is relevant and adheres to style guides.
 
 The Cloud Cost Handbook is organized into two sections: general concepts and per-service pages.
 
-- **General concepts** are meant to cover topics which apply across multiple different infrastructure service.
-- **Per-service pages** are meant to give a brief summary of the service, the pricing dimensions of the service and optionally a list of cost concepts as it relates to that service.
+- **General concepts** are meant to cover topics that apply across multiple different infrastructure services.
+- **Per-service pages** are meant to give a brief summary of the service, the pricing dimensions of the service, and optionally, a list of cost concepts as it relates to that service.
 
 ## Contributing Guidelines
 
-Issues and pull requests are welcome for requesting or contributing content. Vantage employees will review all issues and PRs to ensure we're keeping content relevant and up to standard. You're welcome to get in contact with us on our [Slack Community](https://join.slack.com/t/vantagecommunity/shared_invite/zt-1szz6puz7-zRuJ8J4OJIiBFlcTobYZXA) as well where we have a devoted #cloud-cost-handbook channel for discussion as it relates to the handbook.
+Issues and pull requests (PRs) are welcome for requesting or contributing content. Vantage employees will review all issues and PRs to ensure we're keeping content relevant and up to standard. You're welcome to get in contact with us on our [Slack Community](https://join.slack.com/t/vantagecommunity/shared_invite/zt-1szz6puz7-zRuJ8J4OJIiBFlcTobYZXA) as well where we have a devoted #cloud-cost-handbook channel for discussion as it relates to the handbook.
 
-### Installation
+### Installing Dependencies
+
+This site uses [mkdocs](https://www.mkdocs.org/). Install the following requirements:
 
 ```bash
 pip install --user mkdocs
 pip install --user mkdocs-material
 ```
 
+### Making and Reviewing Changes
+
+Prior to opening a pull request, please review your changes locally:
+1. Create a separate feature branch, based on the `master` branch, and add your changes. 
+1. From your feature branch, run `mkdocs serve`. 
+1. Access and review your changes locally at `http://localhost:8000/`.
+1. Open a PR and we will review your request as well as suggest any other changes. 
+
+
 ### Deploying
+
+Once a PR is merged to the `master` branch, this will trigger a GitHub Actions workflow, which will deploy the site to GitHub Pages. To deploy the site locally, run:
 
 ```bash
 mkdocs gh-deploy --ignore-version
 ```
 
-This site leverages [mkdocs](https://www.mkdocs.org/). Prior to opening a pull request, please review your changes locally by running `mkdocs serve` which will allow you to access and review your changes locally at `http://localhost:8000/`.
-
 ## Keep Up To Date
 
 Feel free to watch/star this repo as we're looking to update the site regularly with additional services and concepts. Vantage also works on the following relevant projects:
 
-- [EC2Instances.info](https://github.com/vantage-sh/ec2instances.info) - An open-source tool for comparing EC2 instance prices and configurations.
-- [The AWS Cost Leaderboard](https://leaderboard.vantage.sh/) - A hosted site of the top AWS cost centers.
-- [Vantage](https://vantage.sh/) - A cloud cost transparency platform.
+- [EC2Instances.info](https://github.com/vantage-sh/ec2instances.info): An open-source tool for comparing EC2 instance prices and configurations.
+- [The AWS Cost Leaderboard](https://leaderboard.vantage.sh/): A hosted site of the top AWS cost centers.
+- [Vantage](https://vantage.sh/): A cloud cost transparency platform.


### PR DESCRIPTION
- Add GH Action to deploy and publish to GH pages
- Update README for contributing
- Addresses #21 

There is an [official mkdocs workflow](https://github.com/marketplace/actions/deploy-mkdocs); however, this method does exactly what we have been doing manually, and I think should suffice. Reminder that once this is approved, we'll just have to turn on the workflow in the Actions console. 